### PR TITLE
Allow an empty string in the `fixed` property

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -127,7 +127,7 @@ export function testRule(schema) {
 				if (!fix) return;
 
 				assert.ok(
-					fixed || fixed === '' || unfixable,
+					typeof fixed === 'string' || unfixable,
 					'If using "{ fix: true }" in test schema, all reject cases must have a "fixed" or "unfixable" property',
 				);
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -127,7 +127,7 @@ export function testRule(schema) {
 				if (!fix) return;
 
 				assert.ok(
-					fixed || unfixable,
+					fixed || fixed === '' || unfixable,
 					'If using "{ fix: true }" in test schema, all reject cases must have a "fixed" or "unfixable" property',
 				);
 


### PR DESCRIPTION
Sometimes it is necessary to make the code become an empty string after the fix.

For example, for the `no-extra-semicolons` rule, a case with the code `";"` should result in `""`.