### PR TITLE
Add `codeFilename` option to `accept`/`reject` cases in `testRule` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Head
+
+- Added: `codeFilename` option to `accept`/`reject` cases in `testRule` function.
+
 ## 0.2.2
 
 - Fixed: missing GitHub Sponsor for `funding` field in `package.json`.

--- a/lib/__tests__/fixtures/plugin-foo.js
+++ b/lib/__tests__/fixtures/plugin-foo.js
@@ -1,3 +1,5 @@
+import path from 'node:path';
+
 import stylelint from 'stylelint';
 
 const {
@@ -8,21 +10,47 @@ const {
 const ruleName = 'plugin/foo';
 
 const messages = ruleMessages(ruleName, {
-	rejected: (/** @type {string} */ selector) => `No "${selector}" selector`,
+	rejected: (selector) => `No "${selector}" selector`,
+	expectFilename: (expected, actual) => `Expect "${actual}" to be "${expected}"`,
 });
 
 /** @type {(value: unknown) => boolean} */
 const isString = (value) => typeof value === 'string';
 
 /** @type {import('stylelint').Rule} */
-const ruleFunction = (primary, _secondaryOptions, { fix }) => {
+const ruleFunction = (primary, secondaryOptions, { fix }) => {
 	return (root, result) => {
-		const validOptions = validateOptions(result, ruleName, {
-			actual: primary,
-			possible: [isString],
-		});
+		const validOptions = validateOptions(
+			result,
+			ruleName,
+			{
+				actual: primary,
+				possible: [isString],
+			},
+			{
+				actual: secondaryOptions,
+				possible: {
+					filename: [isString],
+				},
+				optional: true,
+			},
+		);
 
 		if (!validOptions) {
+			return;
+		}
+
+		const expectedFilename = secondaryOptions?.['filename']; // eslint-disable-line dot-notation
+		const actualFilename = path.basename(root.source?.input.file ?? '');
+
+		if (expectedFilename && expectedFilename !== actualFilename) {
+			report({
+				result,
+				ruleName,
+				message: messages.expectFilename(expectedFilename, actualFilename),
+				node: root,
+			});
+
 			return;
 		}
 

--- a/lib/__tests__/testRule.test.js
+++ b/lib/__tests__/testRule.test.js
@@ -82,3 +82,20 @@ testRule({
 		},
 	],
 });
+
+testRule({
+	plugins,
+	ruleName,
+	config: ['.a', { filename: 'foo.css' }],
+	codeFilename: 'foo.css',
+
+	accept: [{ code: '.a {}' }, { code: '.a {}', codeFilename: 'foo.css' }],
+
+	reject: [
+		{
+			code: '#a {}',
+			codeFilename: 'bar.css',
+			message: messages.expectFilename('foo.css', 'bar.css'),
+		},
+	],
+});

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -8,6 +8,11 @@ export type TestCase = {
 	code: string;
 
 	/**
+	 * A filename for this `code` property.
+	 */
+	codeFilename?: string;
+
+	/**
 	 * Description of the test case.
 	 */
 	description?: string | undefined;

--- a/lib/index.js
+++ b/lib/index.js
@@ -31,35 +31,34 @@ export function testRule(schema) {
 			name: 'accept',
 			cases: accept,
 			schema,
-			comparisons:
-				({ code }) =>
-				async () => {
-					const stylelintOptions = {
-						code,
-						config: stylelintConfig,
-						customSyntax,
-						codeFilename,
-					};
+			comparisons: (testCase) => async () => {
+				const { code } = testCase;
+				const stylelintOptions = {
+					code,
+					config: stylelintConfig,
+					customSyntax,
+					codeFilename: testCase.codeFilename || codeFilename,
+				};
 
-					const { results } = await lint(stylelintOptions);
-					const [result] = results;
+				const { results } = await lint(stylelintOptions);
+				const [result] = results;
 
-					assert.ok(result, 'No lint result');
+				assert.ok(result, 'No lint result');
 
-					const { warnings, parseErrors, invalidOptionWarnings } = result;
+				const { warnings, parseErrors, invalidOptionWarnings } = result;
 
-					assert.deepEqual(warnings, [], 'Warnings are not empty');
-					assert.deepEqual(parseErrors, [], 'Parse errors are not empty');
-					assert.deepEqual(invalidOptionWarnings, [], 'Invalid option warnings are not empty');
+				assert.deepEqual(warnings, [], 'Warnings are not empty');
+				assert.deepEqual(parseErrors, [], 'Parse errors are not empty');
+				assert.deepEqual(invalidOptionWarnings, [], 'Invalid option warnings are not empty');
 
-					if (!fix) return;
+				if (!fix) return;
 
-					// Check that --fix doesn't change code
-					const outputAfterFix = await lint({ ...stylelintOptions, fix: true });
-					const fixedCode = getOutputCss(outputAfterFix);
+				// Check that --fix doesn't change code
+				const outputAfterFix = await lint({ ...stylelintOptions, fix: true });
+				const fixedCode = getOutputCss(outputAfterFix);
 
-					assert.equal(fixedCode, code, 'Fixed code does not equal original code');
-				},
+				assert.equal(fixedCode, code, 'Fixed code does not equal original code');
+			},
 		});
 
 		setupTestCases({
@@ -72,7 +71,7 @@ export function testRule(schema) {
 					code,
 					config: stylelintConfig,
 					customSyntax,
-					codeFilename,
+					codeFilename: testCase.codeFilename || codeFilename,
 				};
 
 				const { results } = await lint(stylelintOptions);


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Similar to stylelint/jest-preset-stylelint#109

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory. See the description in stylelint/jest-preset-stylelint#109.
