### PR TITLE
Add support for testing `referenceFiles` and `languageOptions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Head
+
+- Added: support for testing `referenceFiles`.
+- Added: support for testing `languageOptions`.
+
 ## 1.1.0
 
 - Changed: `stylelint` peer dependency to optional.

--- a/lib/__tests__/fixtures/animations.css
+++ b/lib/__tests__/fixtures/animations.css
@@ -1,0 +1,2 @@
+@keyframes foo {
+}

--- a/lib/__tests__/fixtures/plugin-foo.js
+++ b/lib/__tests__/fixtures/plugin-foo.js
@@ -40,7 +40,7 @@ const ruleFunction = (primary, secondaryOptions) => {
 			return;
 		}
 
-		const expectedFilename = secondaryOptions?.['filename']; // eslint-disable-line dot-notation
+		const expectedFilename = secondaryOptions?.filename;
 		const actualFilename = path.basename(root.source?.input.file ?? '');
 
 		if (expectedFilename && expectedFilename !== actualFilename) {
@@ -55,22 +55,24 @@ const ruleFunction = (primary, secondaryOptions) => {
 		}
 
 		root.walkRules((rule) => {
-			const { selector } = rule;
+			const { selectors } = rule;
 
-			if (primary === selector) return;
-
-			report({
-				result,
-				ruleName,
-				message: messages.rejected(selector),
-				node: rule,
-				word: selector,
-				fix: {
-					apply: () => {
-						rule.selector = primary;
-					},
-					node: rule,
-				},
+			selectors.forEach((selector, index) => {
+				if (primary !== selector) {
+					report({
+						result,
+						ruleName,
+						message: messages.rejected(selector),
+						node: rule,
+						fix: {
+							apply: () => {
+								selectors[index] = primary;
+								rule.selectors = selectors;
+							},
+							node: rule,
+						},
+					});
+				}
 			});
 		});
 	};

--- a/lib/__tests__/testRule.test.js
+++ b/lib/__tests__/testRule.test.js
@@ -4,9 +4,7 @@ import plugin from './fixtures/plugin-foo.js';
 
 const plugins = [plugin];
 const {
-	// @ts-expect-error -- TS2339: Property 'ruleName' does not exist on type 'Plugin'.
 	ruleName,
-	// @ts-expect-error -- TS2339: Property 'rule' does not exist on type 'Plugin'.
 	rule: { messages },
 } = plugin;
 
@@ -35,36 +33,6 @@ testRule({
 			message: messages.rejected('#a'),
 			description: 'with description',
 		},
-		{
-			code: '#a {}',
-			message: messages.rejected('#a'),
-			description: 'with location',
-			line: 1,
-			column: 1,
-			endLine: 1,
-			endColumn: 3,
-		},
-		{
-			code: '#a {} #b {}',
-			description: 'multiple warnings',
-			warnings: [
-				{
-					message: messages.rejected('#a'),
-				},
-				{
-					message: messages.rejected('#b'),
-					line: 1,
-					column: 7,
-					endLine: 1,
-					endColumn: 9,
-				},
-			],
-		},
-		{
-			code: '#a {',
-			message: 'Unclosed block (CssSyntaxError)',
-			description: 'syntax error',
-		},
 	],
 });
 
@@ -72,28 +40,19 @@ testRule({
 	plugins,
 	ruleName,
 	config: ['.a'],
-	fix: true,
-
-	reject: [
-		{
-			code: '#a {}',
-			fixed: '.a {}',
-			message: messages.rejected('#a'),
-		},
-	],
+	loadLint: () => import('stylelint').then((m) => m.default.lint),
+	accept: [{ code: '.a {}' }],
 });
 
 testRule({
 	plugins,
 	ruleName,
-	config: ['.a', { filename: 'foo.css' }],
 	codeFilename: 'foo.css',
-
+	config: ['.a', { filename: 'foo.css' }],
 	accept: [{ code: '.a {}' }, { code: '.a {}', codeFilename: 'foo.css' }],
-
 	reject: [
 		{
-			code: '#a {}',
+			code: '.a {}',
 			codeFilename: 'bar.css',
 			message: messages.expectFilename('foo.css', 'bar.css'),
 		},
@@ -125,6 +84,103 @@ testRule({
 				range: [6, 7],
 				text: '.',
 			},
+		},
+		{
+			code: '#a, #a {}',
+			warnings: [
+				{
+					message: messages.rejected('#a'),
+					fix: {
+						range: [0, 1],
+						text: '.',
+					},
+				},
+				{
+					message: messages.rejected('#a'),
+				},
+			],
+		},
+	],
+});
+
+testRule({
+	plugins,
+	ruleName,
+	config: ['.a'],
+	fix: true,
+	computeEditInfo: true,
+
+	accept: [],
+
+	reject: [
+		{
+			code: '#a {}',
+			fixed: '.a {}',
+			message: messages.rejected('#a'),
+			fix: {
+				range: [0, 1],
+				text: '.',
+			},
+		},
+		{
+			code: '.a {} #a {}',
+			fixed: '.a {} .a {}',
+			message: messages.rejected('#a'),
+			description: 'with description',
+			fix: {
+				range: [6, 7],
+				text: '.',
+			},
+		},
+	],
+});
+
+testRule({
+	ruleName: 'at-rule-descriptor-no-unknown',
+	config: true,
+	languageOptions: {
+		syntax: {
+			atRules: {
+				foo: {
+					descriptors: {
+						bar: '<number>',
+					},
+				},
+			},
+		},
+	},
+
+	accept: [
+		{
+			code: '@foo { bar: 1; }',
+		},
+	],
+
+	reject: [
+		{
+			code: '@foo { baz: 1; }',
+			message: 'Unknown descriptor "baz" for at-rule "@foo" (at-rule-descriptor-no-unknown)',
+		},
+	],
+});
+
+testRule({
+	ruleName: 'no-unknown-animations',
+	config: true,
+	referenceFiles: {
+		files: 'lib/__tests__/fixtures/animations.css',
+	},
+
+	accept: [
+		{
+			code: 'a { animation-name: foo; }',
+		},
+	],
+
+	reject: [
+		{
+			code: 'a { animation-name: bar; }',
+			message: 'Unknown animation "bar" (no-unknown-animations)',
 		},
 	],
 });

--- a/lib/__tests__/testRuleConfigs.test.js
+++ b/lib/__tests__/testRuleConfigs.test.js
@@ -3,7 +3,6 @@ import { testRuleConfigs } from '../index.js';
 import plugin from './fixtures/plugin-foo.js';
 
 const plugins = [plugin];
-// @ts-expect-error -- TS2339: Property 'ruleName' does not exist on type 'Plugin'.
 const { ruleName } = plugin;
 
 testRuleConfigs({

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -149,6 +149,24 @@ export type TestSchema = {
 	plugins?: import('stylelint').Config['plugins'] | undefined;
 
 	/**
+	 * Maps to Stylelint's `languageOptions` configuration property.
+	 * Allows customization of syntax for at-rules, properties, types, and CSS-wide keywords.
+	 *
+	 * @experimental
+	 *
+	 * @see https://stylelint.io/user-guide/configure/#languageoptions
+	 */
+	languageOptions?: import('stylelint').Config['languageOptions'];
+
+	/**
+	 * Maps to Stylelint's `referenceFiles` configuration property.
+	 * An array of globs or objects to specify what files to get reference information from
+	 *
+	 * @see https://stylelint.io/user-guide/configure/#referencefiles
+	 */
+	referenceFiles?: import('stylelint').Config['referenceFiles'];
+
+	/**
 	 * Maps to Stylelint's `customSyntax` option.
 	 *
 	 * @see https://stylelint.io/user-guide/usage/options#customsyntax

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,6 +14,8 @@ export function testRule(schema) {
 		config,
 		plugins,
 		customSyntax,
+		languageOptions,
+		referenceFiles,
 		codeFilename,
 		fix,
 		accept = [],
@@ -26,6 +28,8 @@ export function testRule(schema) {
 		const stylelintConfig = {
 			plugins,
 			rules: { [ruleName]: config },
+			languageOptions,
+			referenceFiles,
 		};
 
 		setupTestCases({


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

See: https://github.com/stylelint/jest-preset-stylelint/issues/224

> Is there anything in the PR that needs further explanation?

This back ports missing features from `jest-preset-stylelint` and also brings the test files back in sync.