### PR TITLE
Fix type for experimental status of `referenceFiles`

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -152,8 +152,6 @@ export type TestSchema = {
 	 * Maps to Stylelint's `languageOptions` configuration property.
 	 * Allows customization of syntax for at-rules, properties, types, and CSS-wide keywords.
 	 *
-	 * @experimental
-	 *
 	 * @see https://stylelint.io/user-guide/configure/#languageoptions
 	 */
 	languageOptions?: import('stylelint').Config['languageOptions'];
@@ -161,6 +159,8 @@ export type TestSchema = {
 	/**
 	 * Maps to Stylelint's `referenceFiles` configuration property.
 	 * An array of globs or objects to specify what files to get reference information from
+	 *
+	 * @experimental
 	 *
 	 * @see https://stylelint.io/user-guide/configure/#referencefiles
 	 */


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref https://github.com/stylelint/stylelint-test-rule-node/pull/128

> Is there anything in the PR that needs further explanation?

Moves it from `languageOptions` to `referenceFiles`

I can release the two packages after this is merged.
