### PR TITLE
Respect default cooldown period for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,8 +12,6 @@ updates:
       dev-deps:
         dependency-type: development
         exclude-patterns: ['stylelint']
-    cooldown:
-      default-days: 7
 
   - package-ecosystem: github-actions
     directory: '/'
@@ -26,5 +24,4 @@ updates:
       stylelint-actions:
         patterns: ['stylelint/.github/*']
     cooldown:
-      default-days: 7
       exclude: ['stylelint/.github/*']


### PR DESCRIPTION

<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

Applies a default cooldown period of 3 days.

See also:
- https://github.blog/changelog/2026-07-14-dependabot-version-updates-introduce-default-package-cooldown/
- https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-
